### PR TITLE
WIP - 1 spec fails - Doesn't load stop words

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,11 +4,9 @@ version: 0.1.0
 authors:
   - Chris Watson <cawatson1993@gmail.com>
 
-crystal: 0.30.1
+crystal: 0.31.1
 
 dependencies:
-  cadmium_util:
-    github: cadmiumcr/utilities
   cadmium_tokenizer:
     github: cadmiumcr/tokenizer
 

--- a/src/cadmium/stemmer/stemmer/porter_stemmer.cr
+++ b/src/cadmium/stemmer/stemmer/porter_stemmer.cr
@@ -2,6 +2,14 @@ require "./stemmer"
 
 module Cadmium
   class PorterStemmer < Stemmer
+    include Tokenizer::StopWords
+    @@stop_words = Set(String).new
+
+    def initialize
+      add_stopwords_list(:en)
+      @@stop_words.concat @@loaded_stop_words[:en] if @@stop_words.empty?
+    end
+
     def self.stem(token : String)
       return token if token.size < 3
       step5b(step5a(step4(step3(step2(step1c(step1b(step1a(token.downcase)))))))).to_s

--- a/src/cadmium/stemmer/stemmer/stemmer.cr
+++ b/src/cadmium/stemmer/stemmer/stemmer.cr
@@ -1,28 +1,14 @@
 module Cadmium
   abstract class Stemmer
-    include Cadmium::Util::StopWords
+    include Tokenizer::StopWords
+
+    def initialize
+      add_stopwords_list(:en)
+      @@stop_words.concat @@loaded_stop_words[:en] if @@stop_words.empty?
+    end
 
     def self.stem(token)
       token
-    end
-
-    def self.add_stop_word(word)
-      @@stop_words.push word
-    end
-
-    def self.add_stop_words(words)
-      @@stop_words.concat words
-    end
-
-    def self.remove_stop_word(word)
-      remove_stop_words([word])
-    end
-
-    def self.remove_stop_words(words)
-      words.each do |word|
-        @@stop_words.delete(word)
-      end
-      @@stop_words
     end
 
     def self.tokenize_and_stem(text, keep_stops = false)

--- a/src/cadmium_stemmer.cr
+++ b/src/cadmium_stemmer.cr
@@ -1,3 +1,2 @@
-require "cadmium_util"
 require "cadmium_tokenizer"
 require "./cadmium/stemmer"


### PR DESCRIPTION
@watzon : this is a call for help.

My sanity is at stake.

After hours trying to load english stop words from the new `Cadmium::Tokenizer::StopWords `module : 
- I got insulted with compiler errors talking about meta class instances
- An unknown cat has been watching me on my balcony

If you could just take a look at what is going wrong there, I really have no clue.

Especially, I don't know what differs from `Tokenizer::Pragmatic` with how the stop_words are loaded...
